### PR TITLE
add videos for setup instructions

### DIFF
--- a/examples/how-to-use.md
+++ b/examples/how-to-use.md
@@ -13,6 +13,10 @@ The output shows the base64 representation of the string mapr is `bWFwcg==`
       
 ### Static Volume Provisioning
 
+The following video demonstrates the procedure for static provisioning in a single-node Kubernetes cluster and the MapR sandbox:
+
+[![asciicast](https://asciinema.org/a/rPc7SQswjJPB5DuPJnQ8K4Zi8.svg)](https://asciinema.org/a/rPc7SQswjJPB5DuPJnQ8K4Zi8)
+
 Run the following examples from the `examples` directory for static provisioning.
 
 ```bash
@@ -71,6 +75,10 @@ kubectl exec -it <pod> -n test-csi -- ls -l <volume-mount-path>
 ```
 
 ### Dynamic Volume Provisioning
+
+The following video demonstrates the procedure for dynamic provisioning in a single-node Kubernetes cluster and the MapR sandbox:
+
+[![asciicast](https://asciinema.org/a/225777.svg)](https://asciinema.org/a/225777)
 
 Run the following examples from the `examples` directory for dynamic provisioning.
 

--- a/examples/how-to-use.md
+++ b/examples/how-to-use.md
@@ -15,7 +15,7 @@ The output shows the base64 representation of the string mapr is `bWFwcg==`
 
 The following video demonstrates the procedure for static provisioning in a single-node Kubernetes cluster and the MapR sandbox:
 
-[![asciicast](https://asciinema.org/a/rPc7SQswjJPB5DuPJnQ8K4Zi8.svg)](https://asciinema.org/a/rPc7SQswjJPB5DuPJnQ8K4Zi8)
+<a href="https://asciinema.org/a/rPc7SQswjJPB5DuPJnQ8K4Zi8" target="_blank"><img src="https://asciinema.org/a/rPc7SQswjJPB5DuPJnQ8K4Zi8.svg" width="400"/></a>
 
 Run the following examples from the `examples` directory for static provisioning.
 
@@ -78,7 +78,7 @@ kubectl exec -it <pod> -n test-csi -- ls -l <volume-mount-path>
 
 The following video demonstrates the procedure for dynamic provisioning in a single-node Kubernetes cluster and the MapR sandbox:
 
-[![asciicast](https://asciinema.org/a/225777.svg)](https://asciinema.org/a/225777)
+<a href="https://asciinema.org/a/225777" target="_blank"><img src="https://asciinema.org/a/225777.svg" width="400"/></a>
 
 Run the following examples from the `examples` directory for dynamic provisioning.
 


### PR DESCRIPTION
asciinema was used to record videos for static and dynamic provisioning. Might be useful to add them to the instructions to break up the wall of text.