### PR TITLE
Updating version of livenessprobe to newer version

### DIFF
--- a/deploy/kubernetes/csi-maprkdf-v1.0.0.yaml
+++ b/deploy/kubernetes/csi-maprkdf-v1.0.0.yaml
@@ -190,7 +190,7 @@ spec:
             - name: registration-dir
               mountPath: /registration/
         - name: liveness-probe
-          image: quay.io/k8scsi/livenessprobe:v1.0.1
+          image: quay.io/k8scsi/livenessprobe:v1.0.2
           imagePullPolicy: "Always"
           args:
             - "--v=5"
@@ -324,7 +324,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: liveness-probe
-          image: quay.io/k8scsi/livenessprobe:v1.0.1
+          image: quay.io/k8scsi/livenessprobe:v1.0.2
           imagePullPolicy: "Always"
           args:
             - "--v=5"


### PR DESCRIPTION
Updated the deployment yaml to use livenessprobe:v1.0.2.  1.0.1 has a bug that will cause the livenessprobe to use all files and then restart.  Please see MapR Support Case #00086418